### PR TITLE
Fix signup loading indicator

### DIFF
--- a/app/(auth-pages)/sign-up/page.tsx
+++ b/app/(auth-pages)/sign-up/page.tsx
@@ -164,7 +164,7 @@ export default function Signup() {
             </CardHeader>
 
             <CardContent>
-              <form className="space-y-6" action={signUpAction}>
+              <form className="space-y-6" action={handleFormSubmit}>
                 {/* User Type Selection */}
                 <div className="space-y-3">
                   <Label className="text-base font-semibold flex items-center gap-2">


### PR DESCRIPTION
## Summary
- fix signup form action to call handleFormSubmit so professor validation indicator works

## Testing
- `npm install`
- `npx next lint` *(fails: prompts ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_683f3b312568832aa347ef881b172865