### PR TITLE
Fix login redirect to dashboard

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -301,7 +301,7 @@ export const signInAction = async (formData: FormData) => {
       // Continue to protected route
     }
 
-    return redirect("/protected");
+    return redirect("/dashboard");
 
   } catch (error) {
     // Only catch actual errors, not redirect exceptions

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -70,6 +70,6 @@ export async function GET(request: Request) {
   }
 
   // URL to redirect to after sign up process completes
-  console.log('🔄 Redirecting to protected route');
-  return NextResponse.redirect(`${origin}/protected`);
+  console.log('🔄 Redirecting to dashboard');
+  return NextResponse.redirect(`${origin}/dashboard`);
 }


### PR DESCRIPTION
## Summary
- change sign-in action redirect to `/dashboard`
- redirect auth callback to dashboard instead of protected route

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_683f9eee4adc832aab06f8766fb8108f