### PR TITLE
Create pesquisas page and welcome home

### DIFF
--- a/app/main-layout-client-wrapper.tsx
+++ b/app/main-layout-client-wrapper.tsx
@@ -42,7 +42,9 @@ function HeaderContent() {
       <div className="w-full max-w-5xl flex justify-between items-center p-3 px-5 text-sm">
         {/* Brand/Logo section */}
         <div className="flex gap-5 items-center font-semibold">
-          <Link href={"/"}>CEA UFBA</Link>
+          <Link href="/">CEA UFBA</Link>
+          <Link href="/">Início</Link>
+          <Link href="/pesquisas">Pesquisas</Link>
         </div>
         
         {/* Navigation controls */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,9 @@
-import ResearchOpportunitiesList from "@/components/research/research-opportunities-list";
-
-/**
- * Home Page Component
- * 
- * This is the main landing page of the application that displays
- * a list of research opportunities in an infinite scroll format.
- * 
- * Core functionality:
- * - Displays research opportunities from the database
- * - Implements infinite scrolling for better performance
- * - Serves as the primary entry point for users
- */
-export default async function Home() {
+export default function Welcome() {
   return (
-    <>
-      <main className="flex-1 flex flex-col gap-6 px-4">
-        {/* Main research opportunities infinite scroll component */}
-        <ResearchOpportunitiesList />
-      </main>
-    </>
+    <main className="flex-1 flex flex-col items-center justify-center gap-6 px-4 text-center">
+      <h1 className="text-3xl font-bold">Bem-vindo ao CEA UFBA</h1>
+      <p className="text-muted-foreground">Use o menu para navegar e acessar as pesquisas disponíveis.</p>
+    </main>
   );
 }
+

--- a/app/pesquisas/page.tsx
+++ b/app/pesquisas/page.tsx
@@ -1,0 +1,23 @@
+import ResearchOpportunitiesList from "@/components/research/research-opportunities-list";
+
+/**
+ * Home Page Component
+ * 
+ * This is the main landing page of the application that displays
+ * a list of research opportunities in an infinite scroll format.
+ * 
+ * Core functionality:
+ * - Displays research opportunities from the database
+ * - Implements infinite scrolling for better performance
+ * - Serves as the primary entry point for users
+ */
+export default async function Home() {
+  return (
+    <>
+      <main className="flex-1 flex flex-col gap-6 px-4">
+        {/* Main research opportunities infinite scroll component */}
+        <ResearchOpportunitiesList />
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/pesquisas` route containing the original research list
- create a new landing page with a welcome message
- expose `Início` and `Pesquisas` links in the header navigation

## Testing
- `npx next lint` *(fails: Need to install next)*

------
https://chatgpt.com/codex/tasks/task_e_683fb5743d6c832a8458b66d7ee0b118